### PR TITLE
Change github urls in instructions to match links above 

### DIFF
--- a/about.mdwn
+++ b/about.mdwn
@@ -13,8 +13,8 @@ Setup process:
 1. follow instructions here: [[http://ikiwiki.info/install/]]
 1. create a user called `perltuthub`, then `su` to it and `cd ~`
 1. setup .ssh dir
-1. git clone git@github.com:Perl-Tutorial-Curators/perltut-base.git .
-1. git clone git@github.com:Perl-Tutorial-Curators/perltut-data.git PerlTutorialHub
+1. git clone git@github.com:perl-doc-cats/perl-tutorial-org-base.git .
+1. git clone git@github.com:perl-doc-cats/perl-tutorial-org-data.git PerlTutorialHub
 1. ikiwiki -setup ~/PerlTutorialHub.setup
 1. point web server at `public_html/PerlTutorialHub`
 1. set up empty cgi handler to execute ikiwiki.cgi ELF file


### PR DESCRIPTION
The links were changed but not the git urls in the setup steps
